### PR TITLE
Fixed multiline regexp vuln by trying to avoid regexp all together

### DIFF
--- a/spec/lib/safe_redirect/safe_redirect_spec.rb
+++ b/spec/lib/safe_redirect/safe_redirect_spec.rb
@@ -13,15 +13,20 @@ module SafeRedirect
     SAFE_PATHS = [
       'https://www.bukalapak.com',
       '/',
+      '/foobar',
       'http://www.twitter.com',
       :back,
       { controller: 'home', action: 'index' }
     ]
 
-    UNSAFE_PATHS = %w(// https://www.bukalapak.com@google.com http://////@@@@@@attacker.com//evil.com
-                      .@@@google.com //bukalapak.com%25%40%25%40%25%40%25%40%25%40%25%40%25%40evil.com
-                      %25%40%25%40%25%40%25%40%25%40%25%40%25%40%25%40%25%40%25%40evil.com 
-                      %@%@%@%@%@%@%@%@%@%@evil.com https://www-bukalapak.com)
+    UNSAFE_PATHS = [
+      "https://www.bukalapak.com@google.com",
+      "http://////@@@@@@attacker.com//evil.com",
+      "//bukalapak.com%25%40%25%40%25%40%25%40%25%40%25%40%25%40evil.com",
+      "%@%@%@%@%@%@%@%@%@%@evil.com",
+      "https://www-bukalapak.com",
+      "https://www.bukalapak.com\n.evil.com",
+    ]
 
     SAFE_PATHS.each do |path|
       it "considers #{path} a safe path" do


### PR DESCRIPTION
there was a vulnerability in the use of ^ and $ in the regexp, i added a failing test case path with a new line in it:

    https://www.bukalapak.com\n.evil.com

i thought using the URI standard lib instead simplifies the code and probably sures it up against these kinds of regexp mistakes, what are your thoughts?