### PR TITLE
Added domain wildcard for whitelisted hosts.

### DIFF
--- a/lib/safe_redirect/configuration.rb
+++ b/lib/safe_redirect/configuration.rb
@@ -12,11 +12,20 @@ module SafeRedirect
   end
 
   class Configuration
-    attr_accessor :default_path, :domain_whitelists
+    attr_accessor :default_path
+    attr_reader :domain_whitelists
 
     def initialize
       self.default_path = '/'
       self.domain_whitelists = []
+    end
+
+    def domain_whitelists=(whitelists)
+      if whitelists.any?{ |w| w =~ /\*\z/ }
+        raise ArgumentError, "whitelisted domain cannot end with a glob (*)"
+      end
+
+      @domain_whitelists = whitelists
     end
   end
 end

--- a/lib/safe_redirect/safe_redirect.rb
+++ b/lib/safe_redirect/safe_redirect.rb
@@ -3,7 +3,27 @@ require 'uri'
 module SafeRedirect
   def safe_domain?(uri)
     return true if uri.host.nil? && uri.scheme.nil?
-    SafeRedirect.configuration.domain_whitelists.include?(uri.host)
+    return false if uri.host.nil?
+
+    SafeRedirect.configuration.domain_whitelists.any? do |domain|
+      if domain.include?("*")
+        rf = domain.split(/(\*)/).map{ |f| f == "*" ? "\\w*" : Regexp.escape(f) }
+        regexp = Regexp.new("\\A#{rf.join}\\z")
+
+        safe = uri.host.match(regexp)
+
+        # if domain starts with *. and contains no other wildcards, include the
+        # naked domain too (e.g. foo.org when *.foo.org is the whitelist)
+        if domain =~ /\A\*\.[^\*]+\z/
+          naked_domain = domain.gsub("*.", "")
+          safe || uri.host == naked_domain
+        else
+          safe
+        end
+      else
+        uri.host == domain
+      end
+    end
   end
 
   def safe_path(path)

--- a/spec/lib/safe_redirect/configuration_spec.rb
+++ b/spec/lib/safe_redirect/configuration_spec.rb
@@ -6,6 +6,16 @@ module SafeRedirect
       reset_config
     end
 
+    it 'errors if you try to end whitelisted domain with glob' do
+      config_update = -> do
+        SafeRedirect.configure do |config|
+          config.domain_whitelists = ["foo.*"]
+        end
+      end
+
+      expect(config_update).to raise_error(ArgumentError)
+    end
+
     it 'default default_path is /' do
       expect(SafeRedirect.configuration.default_path).to eq('/')
     end

--- a/spec/lib/safe_redirect/safe_redirect_spec.rb
+++ b/spec/lib/safe_redirect/safe_redirect_spec.rb
@@ -15,8 +15,10 @@ module SafeRedirect
       '/',
       '/foobar',
       'http://www.twitter.com',
+      'http://blah.foo.org',
+      'http://foo.org',
       :back,
-      { controller: 'home', action: 'index' }
+      { controller: 'home', action: 'index' },
     ]
 
     UNSAFE_PATHS = [
@@ -26,6 +28,7 @@ module SafeRedirect
       "%@%@%@%@%@%@%@%@%@%@evil.com",
       "https://www-bukalapak.com",
       "https://www.bukalapak.com\n.evil.com",
+      "http://blah.blah.foo.org",
     ]
 
     SAFE_PATHS.each do |path|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 def load_config
   SafeRedirect.configure do |config|
     config.default_path = '/sdsdkkk'
-    config.domain_whitelists = ['www.twitter.com', 'www.bukalapak.com']
+    config.domain_whitelists = %w{www.twitter.com www.bukalapak.com *.foo.org}
   end
 end
 


### PR DESCRIPTION
just an idea to allow the use of wildcard '*' in whitelisted domains to signify that anything at that portion of a domain is acceptable.

if you whitelisted '*.foo.org' it should permit redirects to abc.foo.org and def.foo.org but not blah.blah.foo.org