### PR TITLE
Add config option to log SafeRedirect violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Create a `config/initializer/safe_redirect.rb` file.
 SafeRedirect.configure do |config|
   config.default_path = 'https://www.yahoo.com' # default value: '/'
   config.domain_whitelists = ['www.google.com'] # default value: []
+  config.log = Rails.env.development?           # default value: false
 end
 ```
 

--- a/lib/safe_redirect/configuration.rb
+++ b/lib/safe_redirect/configuration.rb
@@ -12,13 +12,14 @@ module SafeRedirect
   end
 
   class Configuration
-    attr_accessor :default_path, :whitelist_local
+    attr_accessor :default_path, :whitelist_local, :log
     attr_reader :domain_whitelists
 
     def initialize
       self.default_path = '/'
       self.whitelist_local = false
       self.domain_whitelists = []
+      self.log = false
     end
 
     def domain_whitelists=(whitelists)

--- a/spec/lib/safe_redirect/configuration_spec.rb
+++ b/spec/lib/safe_redirect/configuration_spec.rb
@@ -28,6 +28,10 @@ module SafeRedirect
       expect(SafeRedirect.configuration.domain_whitelists).to eq([])
     end
 
+    it 'default log is false' do
+      expect(SafeRedirect.configuration.log).to eq(false)
+    end
+
     it 'can update default_path' do
       SafeRedirect.configure do |config|
         config.default_path = 'https://www.bukalapak.com'
@@ -47,6 +51,13 @@ module SafeRedirect
         config.domain_whitelists = ['www.bukalapak.com']
       end
       expect(SafeRedirect.configuration.domain_whitelists).to eq(['www.bukalapak.com'])
+    end
+
+    it 'can update log' do
+      SafeRedirect.configure do |config|
+        config.log = true
+      end
+      expect(SafeRedirect.configuration.log).to eq(true)
     end
   end
 end

--- a/spec/lib/safe_redirect/safe_redirect_spec.rb
+++ b/spec/lib/safe_redirect/safe_redirect_spec.rb
@@ -1,8 +1,16 @@
 require 'spec_helper'
+require 'stringio'
+require 'logger'
 
 module SafeRedirect
   describe SafeRedirect do
-    class Controller
+    class BaseController
+      def redirect_to(*)
+        # test stub
+      end
+    end
+
+    class Controller < BaseController
       extend SafeRedirect
     end
 
@@ -58,10 +66,19 @@ module SafeRedirect
       it 'can use redirect_to method with both the target path and the options' do
         Controller.redirect_to '/', notice: 'Back to home page'
       end
+
+      it 'can log violations' do
+        log_io = StringIO.new
+        SafeRedirect.configure{ |config| config.log = Logger.new(log_io) }
+
+        Controller.redirect_to(UNSAFE_PATHS.first)
+
+        expect(log_io.size).not_to eq(0)
+      end
     end
 
     context 'whitelist_local is not set' do
-  
+
       before(:all) do
         load_config
       end
@@ -75,7 +92,7 @@ module SafeRedirect
     end
 
     context 'whitelist_local is set' do
-  
+
       before(:all) do
         load_config true
       end


### PR DESCRIPTION
If log config option is set to true it will try to log to Rails.logger,
if it's set to an instance of Logger it will log to that. It logs when
the safe version of the redirect uri is different to the requested
redirect.

Knocked this up pretty quick, not sure what you think?