### PR TITLE
Fix wildcard regexp parsing

### DIFF
--- a/lib/safe_redirect/safe_redirect.rb
+++ b/lib/safe_redirect/safe_redirect.rb
@@ -7,7 +7,7 @@ module SafeRedirect
 
     SafeRedirect.configuration.domain_whitelists.any? do |domain|
       if domain.include?("*")
-        rf = domain.split(/(\*)/).map{ |f| f == "*" ? "\\w*" : Regexp.escape(f) }
+        rf = domain.split(/(\*)/).map{ |f| f == "*" ? "[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]?" : Regexp.escape(f) }
         regexp = Regexp.new("\\A#{rf.join}\\z")
 
         safe = uri.host.match(regexp)


### PR DESCRIPTION
Previously, it was just using \w* for the wildcard parts, but \w doesn't
catch subdomains with dashes in, which are valid. Updated this regexp
based on subdomain spec which is that it must begin and end with an
alphanumeric, but can have dashes inbetween.