### PR TITLE
Extend self to allow calling methods directly

### DIFF
--- a/lib/safe_redirect/safe_redirect.rb
+++ b/lib/safe_redirect/safe_redirect.rb
@@ -1,6 +1,8 @@
 require 'uri'
 
 module SafeRedirect
+  extend self
+
   def safe_domain?(uri)
     return true if valid_uri?(uri)
     return false if uri.host.nil?


### PR DESCRIPTION
### What are you trying to accomplish in this PR?
Currently the `SafeRedirect` doesn't allow you to call the methods directly, you have to include it in a module or class. You can also do the following, where you can extend the class object and then call it:
```rb
Class.new.extend(SafeRedirect).safe_domain?(URI.parse(url))
```

To solve this issue I have extended the `SafeRedirect` module to itself. This would allows us to call the methods directly without include the `SafeRedirect` module in our classes or modules.

### Manual testing 🎩 
#### Setup
First thing we need to do is create `redirect_to` method since this only exists in `ActionController`

```rb
def redirect_to(url, options)
  [url, options]
end
```
#### Testing the changes
To manually test the changes, first we require the gem and then call the methods directly, like the following 👇 

```rb
require './lib/safe_redirect/safe_redirect'

SafeRedirect.safe_domain?(URI.parse('/helloworld'))
#=> true

SafeRedirect.safe_path(URI.parse('//example.com'))
#=> #<URI::Generic //example.com>

SafeRedirect.redirect_to('//example.com')
#=> ["/", {}]

SafeRedirect.redirect_to('/example.com')
#=> ["/example.com", {}]
```