### PR TITLE
Add URI components match in safe_domain?

### DIFF
--- a/lib/safe_redirect/safe_redirect.rb
+++ b/lib/safe_redirect/safe_redirect.rb
@@ -1,5 +1,4 @@
 require 'uri'
-require 'pry'
 
 module SafeRedirect
   def safe_domain?(uri)

--- a/spec/lib/safe_redirect/safe_redirect_spec.rb
+++ b/spec/lib/safe_redirect/safe_redirect_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'stringio'
 require 'logger'
+require 'pry'
 
 module SafeRedirect
   describe SafeRedirect do
@@ -105,5 +106,62 @@ module SafeRedirect
         expect(Controller.safe_path(path)).to eq(path)
       end
     end
+
+    describe "#safe_domain?" do
+      let(:allowlist) do
+        [
+          'https://www.bukalapak.com',
+          'https://www.bar.foo.com/path',
+          'https://documents.foo.com/access/jwt',
+          'https://*.foo.com',
+          'https://*.test.com/good-end-point'
+        ]
+      end
+
+      before do
+        allow(SafeRedirect.configuration).to receive(:domain_whitelists).and_return(allowlist)
+      end
+      
+      it "allows domains in the allowlist", :aggregate_failures do
+        expect(Controller.safe_domain?(URI('https://www.bukalapak.com'))).to be_truthy
+        expect(Controller.safe_domain?(URI('https://www.bar.foo.com/path'))).to be_truthy
+        expect(Controller.safe_domain?(URI('https://documents.foo.com/access/jwt'))).to be_truthy
+        expect(Controller.safe_domain?(URI('https://good.foo.com'))).to be_truthy
+        expect(Controller.safe_domain?(URI('https://us.test.com/good-end-point'))).to be_truthy
+        expect(Controller.safe_domain?(URI('https://us.test.com/good-end-point/password=123'))).to be_truthy
+      end
+
+      it "allows domains with or without trailing slash" do
+        expect(Controller.safe_domain?(URI('https://www.bukalapak.com'))).to be_truthy
+        expect(Controller.safe_domain?(URI('https://www.bukalapak.com/'))).to be_truthy
+      end
+      
+      it "allows domains that start with an allowed domain" do
+        expect(Controller.safe_domain?(URI('https://www.bukalapak.com/path'))).to be_truthy
+      end
+
+      it "disallows the domains not in the allowlist" do
+        expect(Controller.safe_domain?(URI('https://www.evil.com'))).to be_falsey
+      end
+
+      it "disallows domains that include url components not in the allowlist, wildcard included" do
+        expect(Controller.safe_domain?(URI("https://test.com/evil-endpoint/password=hahaha"))).to be_falsey
+        expect(Controller.safe_domain?(URI("https://good-website.test.com/evil-endpoint"))).to be_falsey
+      end
+
+      it "disallows domains that include a domain from the allowlist as part of the url", :aggregate_failures do
+        expect(Controller.safe_domain?(URI("https://example.com/bukalapak.com"))).to be_falsey
+        expect(Controller.safe_domain?(URI('https://www.bukalapak.com.evil.com'))).to be_falsey
+      end
+
+      it "disallows an allowed domain if we prepend subdomain bits" do
+        expect(Controller.safe_domain?(URI("https://evil.documents.foo.com/access/jwt?token=123"))).to be_falsey
+      end
+
+      it "disallows an allowed domain if URI scheme is different" do
+        expect(Controller.safe_domain?(URI("http://www.bukalapak.com"))).to be_falsey
+      end
+    end
+    
   end
 end

--- a/spec/lib/safe_redirect/safe_redirect_spec.rb
+++ b/spec/lib/safe_redirect/safe_redirect_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'stringio'
 require 'logger'
-require 'pry'
 
 module SafeRedirect
   describe SafeRedirect do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 def load_config(whitelist_local = false)
   SafeRedirect.configure do |config|
     config.default_path = '/sdsdkkk'
-    config.domain_whitelists = %w{www.twitter.com www.bukalapak.com *.foo.org}
+    config.domain_whitelists = %w{http://www.twitter.com https://www.bukalapak.com http://*.foo.org}
     config.whitelist_local = whitelist_local
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 def load_config(whitelist_local = false)
   SafeRedirect.configure do |config|
     config.default_path = '/sdsdkkk'
-    config.domain_whitelists = %w{http://www.twitter.com https://www.bukalapak.com http://*.foo.org}
+    config.domain_whitelists = %w{http://www.twitter.com https://www.bukalapak.com http://*.foo.org https://*.test.com/good-end-point}
     config.whitelist_local = whitelist_local
   end
 end


### PR DESCRIPTION
This PR is aiming to let user to specify the `scheme` in the `domain_whitelists`. Currently the implementation does not fully support that. The following test fails with the current implementation:
For `config.domain_whitelists = %w{https://*.zoom.com}` , the url `https://us.zoom.com` should be considered as a `safe_path` but is not. Similarly, without wildcard, for `config.domain_whitelists = %w{https://us.zoom.com}` the url `https://us.zoom.com` should be considered as a `safe_path` but is not.

We thought it could be a good idea to parse the allowed domains as URI when calling `safe_domain?`. I could be completely misunderstanding the idea behind why @sdsdkkk did not choose to do this though. With this change, users will need to specify for schemes of urls in the `domain_whitelists`.

This PR also refactors the logic quite a bit. It returns definitely `true` or `false` instead of `truthy` or `falsey`. It renames some of the variable with the intention to make it easier to understand. It also breaks down the logic of `safe_domain?` to be checking if the `domain_uri` components are matched with the `uri` by checking for `scheme`, `host`, and `path` URI components.
